### PR TITLE
Update deps and derivation algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,16 @@ readme = "README.md"
 [dependencies]
 proc-macro2 = "0.2.1"
 quote = "0.4.2"
-
-[dependencies.syn]
-version = "0.12.7"
-features = ["full"]
+syn = "0.12.7"
 
 [dev-dependencies]
 compiletest_rs = "0.3.5"
 
 [dev-dependencies.num]
 version = "0.1"
+
+[features]
+full-syntax = ["syn/full"]
 
 [lib]
 name = "num_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ quote = "0.3.15"
 syn = "0.11.11"
 
 [dev-dependencies]
-compiletest_rs = "0.3.3"
+compiletest_rs = "0.3.5"
 
 [dev-dependencies.num]
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ compiletest_rs = "0.3.5"
 [dev-dependencies.num]
 version = "0.1"
 
+[dev-dependencies.num-derive]
+path = "."
+features = ["full-syntax"]
+
 [features]
 full-syntax = ["syn/full"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ version = "0.1.41"
 readme = "README.md"
 
 [dependencies]
-quote = "0.1.3"
-syn = "0.7.0"
+quote = "0.3.15"
+syn = "0.11.11"
 
 [dev-dependencies]
-compiletest_rs = "0.2.5"
+compiletest_rs = "0.3.3"
 
 [dev-dependencies.num]
 version = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ version = "0.1.41"
 readme = "README.md"
 
 [dependencies]
-quote = "0.3.15"
-syn = "0.11.11"
+proc-macro2 = "0.2.1"
+quote = "0.4.2"
+
+[dependencies.syn]
+version = "0.12.7"
+features = ["full"]
 
 [dev-dependencies]
 compiletest_rs = "0.3.5"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-num-derive= "0.1"
+num = "0.1"
+num-derive = "0.1"
 ```
 
 and this to your crate root:
@@ -21,6 +22,16 @@ and this to your crate root:
 #[macro_use]
 extern crate num_derive;
 ```
+
+## Optional features
+
+- **`full-syntax`** — Enables `num-derive` to handle enum discriminants
+  represented by complex expressions. Usually can be avoided by
+  [utilizing constants], so only use this feature if namespace pollution is
+  undesired and [compile time doubling] is acceptable.
+
+[utilizing constants]: https://github.com/rust-num/num-derive/pull/3#issuecomment-359044704
+[compile time doubling]: https://github.com/rust-num/num-derive/pull/3#issuecomment-359172588
 
 ## Compatibility
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
 
             let discriminant_expr = match variant.discriminant {
                 Some(ref const_expr) => {
-                    expr = quote! { #const_expr };
+                    expr = quote! { (#const_expr) as isize };
                     offset = 1;
                     expr.clone()
                 }
@@ -120,7 +120,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
 
             let discriminant_expr = match variant.discriminant {
                 Some(ref const_expr) => {
-                    expr = quote! { #const_expr };
+                    expr = quote! { (#const_expr) as isize };
                     offset = 1;
                     expr.clone()
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use syn::Body::Enum;
+use syn::Ident;
 use syn::VariantData::Unit;
 
 #[proc_macro_derive(FromPrimitive)]
@@ -27,14 +28,17 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
 
     let ast = syn::parse_macro_input(&source).unwrap();
     let name = &ast.ident;
+    let dummy_const = Ident::new(format!("_IMPL_NUM_FROM_PRIMITIVE_FOR_{}", name));
 
     let variants = match ast.body {
         Enum(ref variants) => variants,
         _ => panic!("`FromPrimitive` can be applied only to the enums, {} is not an enum", name)
     };
 
-    let mut idx = 0;
-    let variants: Vec<_> = variants.iter()
+    let from_u64_var = quote! { n };
+    let mut expr = quote! { 0isize };
+    let mut offset = 0isize;
+    let clauses: Vec<_> = variants.iter()
         .map(|variant| {
             let ident = &variant.ident;
             match variant.data {
@@ -43,28 +47,47 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
                     panic!("`FromPrimitive` can be applied only to unitary enums, {}::{} is either struct or tuple", name, ident)
                 },
             }
-            if let Some(val) = variant.discriminant {
-                idx = val.value;
+
+            let discriminant_expr = match variant.discriminant {
+                Some(ref const_expr) => {
+                    expr = quote! { #const_expr };
+                    offset = 1;
+                    expr.clone()
+                }
+                None => {
+                    let tt = quote! { #expr + #offset };
+                    offset += 1;
+                    tt
+                }
+            };
+
+            quote! {
+                if #from_u64_var as isize == #discriminant_expr {
+                    Some(#name::#ident)
+                }
             }
-            let tt = quote!(#idx => Some(#name::#ident));
-            idx += 1;
-            tt
         })
         .collect();
 
-    let res = quote! {
-        impl ::num::traits::FromPrimitive for #name {
-            fn from_i64(n: i64) -> Option<Self> {
-                Self::from_u64(n as u64)
-            }
+    let from_u64_var = if clauses.is_empty() { quote!(_) } else { from_u64_var };
 
-            fn from_u64(n: u64) -> Option<Self> {
-                match n {
-                    #(variants,)*
-                    _ => None,
+    let res = quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy_const: () = {
+            extern crate num as _num;
+
+            impl _num::traits::FromPrimitive for #name {
+                fn from_i64(n: i64) -> Option<Self> {
+                    Self::from_u64(n as u64)
+                }
+
+                fn from_u64(#from_u64_var: u64) -> Option<Self> {
+                    #(#clauses else)* {
+                        None
+                    }
                 }
             }
-        }
+        };
     };
 
     res.to_string().parse().unwrap()
@@ -76,13 +99,15 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
 
     let ast = syn::parse_macro_input(&source).unwrap();
     let name = &ast.ident;
+    let dummy_const = Ident::new(format!("_IMPL_NUM_TO_PRIMITIVE_FOR_{}", name));
 
     let variants = match ast.body {
         Enum(ref variants) => variants,
         _ => panic!("`ToPrimitive` can be applied only to the enums, {} is not an enum", name)
     };
 
-    let mut idx = 0;
+    let mut expr = quote! { 0isize };
+    let mut offset = 0isize;
     let variants: Vec<_> = variants.iter()
         .map(|variant| {
             let ident = &variant.ident;
@@ -92,27 +117,52 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                     panic!("`ToPrimitive` can be applied only to unitary enums, {}::{} is either struct or tuple", name, ident)
                 },
             }
-            if let Some(val) = variant.discriminant {
-                idx = val.value;
-            }
-            let tt = quote!(#name::#ident => #idx);
-            idx += 1;
-            tt
+
+            let discriminant_expr = match variant.discriminant {
+                Some(ref const_expr) => {
+                    expr = quote! { #const_expr };
+                    offset = 1;
+                    expr.clone()
+                }
+                None => {
+                    let tt = quote! { #expr + #offset };
+                    offset += 1;
+                    tt
+                }
+            };
+
+            quote!(#name::#ident => (#discriminant_expr) as u64)
         })
         .collect();
 
-    let res = quote! {
-        impl ::num::traits::ToPrimitive for #name {
-            fn to_i64(&self) -> Option<i64> {
-                self.to_u64().map(|x| x as i64)
-            }
-
-            fn to_u64(&self) -> Option<u64> {
-                Some(match *self {
-                    #(variants,)*
-                })
-            }
+    let match_expr = if variants.is_empty() {
+        // No variants found, so do not use Some to not to trigger #[warn(unreachable_code)]
+        quote! {
+            match *self {}
         }
+    } else {
+        quote! {
+            Some(match *self {
+                #(#variants,)*
+            })
+        }
+    };
+
+    let res = quote! {
+        #[allow(non_upper_case_globals)]
+        const #dummy_const: () = {
+            extern crate num as _num;
+
+            impl _num::traits::ToPrimitive for #name {
+                fn to_i64(&self) -> Option<i64> {
+                    self.to_u64().map(|x| x as i64)
+                }
+
+                fn to_u64(&self) -> Option<u64> {
+                    #match_expr
+                }
+            }
+        };
     };
 
     res.to_string().parse().unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
         };
     };
 
-    res.to_string().parse().unwrap()
+    res.into()
 }
 
 #[proc_macro_derive(ToPrimitive)]
@@ -133,7 +133,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
         .collect();
 
     let match_expr = if variants.is_empty() {
-        // No variants found, so do not use Some to not to trigger #[warn(unreachable_code)]
+        // No variants found, so do not use Some to not to trigger `unreachable_code` lint
         quote! {
             match *self {}
         }
@@ -162,5 +162,5 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
         };
     };
 
-    res.to_string().parse().unwrap()
+    res.into()
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -3,8 +3,10 @@ extern crate compiletest_rs as compiletest;
 use std::path::PathBuf;
 use std::env::var;
 
+use compiletest::Config;
+
 fn run_mode(mode: &'static str) {
-    let mut config = compiletest::default_config();
+    let mut config = Config::default();
 
     let cfg_mode = mode.parse().ok().expect("Invalid mode");
 

--- a/tests/num_derive_without_num.rs
+++ b/tests/num_derive_without_num.rs
@@ -8,16 +8,13 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate num as num_renamed;
 #[macro_use]
 extern crate num_derive;
 
-#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive)]
-enum Color {}
-
-#[test]
-fn test_empty_enum() {
-    let v: [Option<Color>; 1] = [num_renamed::FromPrimitive::from_u64(0)];
-
-    assert_eq!(v, [None]);
+#[derive(Debug, FromPrimitive, ToPrimitive)]
+enum Direction {
+    Up,
+    Down,
+    Left,
+    Right,
 }

--- a/tests/trivial.rs
+++ b/tests/trivial.rs
@@ -8,7 +8,7 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate num;
+extern crate num as num_renamed;
 #[macro_use]
 extern crate num_derive;
 
@@ -21,10 +21,10 @@ enum Color {
 
 #[test]
 fn test_from_primitive_for_trivial_case() {
-    let v: [Option<Color>; 4] = [num::FromPrimitive::from_u64(0),
-                                 num::FromPrimitive::from_u64(1),
-                                 num::FromPrimitive::from_u64(2),
-                                 num::FromPrimitive::from_u64(3)];
+    let v: [Option<Color>; 4] = [num_renamed::FromPrimitive::from_u64(0),
+                                 num_renamed::FromPrimitive::from_u64(1),
+                                 num_renamed::FromPrimitive::from_u64(2),
+                                 num_renamed::FromPrimitive::from_u64(3)];
 
     assert_eq!(v,
                [Some(Color::Red), Some(Color::Blue), Some(Color::Green), None]);
@@ -32,9 +32,9 @@ fn test_from_primitive_for_trivial_case() {
 
 #[test]
 fn test_to_primitive_for_trivial_case() {
-    let v: [Option<u64>; 3] = [num::ToPrimitive::to_u64(&Color::Red),
-                               num::ToPrimitive::to_u64(&Color::Blue),
-                               num::ToPrimitive::to_u64(&Color::Green)];
+    let v: [Option<u64>; 3] = [num_renamed::ToPrimitive::to_u64(&Color::Red),
+                               num_renamed::ToPrimitive::to_u64(&Color::Blue),
+                               num_renamed::ToPrimitive::to_u64(&Color::Green)];
 
     assert_eq!(v, [Some(0), Some(1), Some(2)]);
 }
@@ -43,8 +43,8 @@ fn test_to_primitive_for_trivial_case() {
 fn test_reflexive_for_trivial_case() {
     let before: [u64; 3] = [0, 1, 2];
     let after: Vec<Option<u64>> = before.iter()
-        .map(|&x| -> Option<Color> { num::FromPrimitive::from_u64(x) })
-        .map(|x| x.and_then(|x| num::ToPrimitive::to_u64(&x)))
+        .map(|&x| -> Option<Color> { num_renamed::FromPrimitive::from_u64(x) })
+        .map(|x| x.and_then(|x| num_renamed::ToPrimitive::to_u64(&x)))
         .collect();
     let before = before.into_iter().cloned().map(Some).collect::<Vec<_>>();
 

--- a/tests/with_custom_values.rs
+++ b/tests/with_custom_values.rs
@@ -17,26 +17,29 @@ enum Color {
     Red,
     Blue = 5,
     Green,
+    Alpha = (-3 - (-5isize)) - 10,
 }
 
 #[test]
 fn test_from_primitive_for_enum_with_custom_value() {
-    let v: [Option<Color>; 4] = [num_renamed::FromPrimitive::from_u64(0),
+    let v: [Option<Color>; 5] = [num_renamed::FromPrimitive::from_u64(0),
                                  num_renamed::FromPrimitive::from_u64(5),
                                  num_renamed::FromPrimitive::from_u64(6),
+                                 num_renamed::FromPrimitive::from_u64(-8isize as u64),
                                  num_renamed::FromPrimitive::from_u64(3)];
 
     assert_eq!(v,
-               [Some(Color::Red), Some(Color::Blue), Some(Color::Green), None]);
+               [Some(Color::Red), Some(Color::Blue), Some(Color::Green), Some(Color::Alpha), None]);
 }
 
 #[test]
 fn test_to_primitive_for_enum_with_custom_value() {
-    let v: [Option<u64>; 3] = [num_renamed::ToPrimitive::to_u64(&Color::Red),
+    let v: [Option<u64>; 4] = [num_renamed::ToPrimitive::to_u64(&Color::Red),
                                num_renamed::ToPrimitive::to_u64(&Color::Blue),
-                               num_renamed::ToPrimitive::to_u64(&Color::Green)];
+                               num_renamed::ToPrimitive::to_u64(&Color::Green),
+                               num_renamed::ToPrimitive::to_u64(&Color::Alpha)];
 
-    assert_eq!(v, [Some(0), Some(5), Some(6)]);
+    assert_eq!(v, [Some(0), Some(5), Some(6), Some(-8isize as u64)]);
 }
 
 #[test]

--- a/tests/with_custom_values.rs
+++ b/tests/with_custom_values.rs
@@ -8,11 +8,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-extern crate num;
+extern crate num as num_renamed;
 #[macro_use]
 extern crate num_derive;
 
-#[derive(Debug, PartialEq, FromPrimitive)]
+#[derive(Debug, PartialEq, FromPrimitive, ToPrimitive)]
 enum Color {
     Red,
     Blue = 5,
@@ -21,11 +21,32 @@ enum Color {
 
 #[test]
 fn test_from_primitive_for_enum_with_custom_value() {
-    let v: [Option<Color>; 4] = [num::FromPrimitive::from_u64(0),
-                                 num::FromPrimitive::from_u64(5),
-                                 num::FromPrimitive::from_u64(6),
-                                 num::FromPrimitive::from_u64(3)];
+    let v: [Option<Color>; 4] = [num_renamed::FromPrimitive::from_u64(0),
+                                 num_renamed::FromPrimitive::from_u64(5),
+                                 num_renamed::FromPrimitive::from_u64(6),
+                                 num_renamed::FromPrimitive::from_u64(3)];
 
     assert_eq!(v,
                [Some(Color::Red), Some(Color::Blue), Some(Color::Green), None]);
+}
+
+#[test]
+fn test_to_primitive_for_enum_with_custom_value() {
+    let v: [Option<u64>; 3] = [num_renamed::ToPrimitive::to_u64(&Color::Red),
+                               num_renamed::ToPrimitive::to_u64(&Color::Blue),
+                               num_renamed::ToPrimitive::to_u64(&Color::Green)];
+
+    assert_eq!(v, [Some(0), Some(5), Some(6)]);
+}
+
+#[test]
+fn test_reflexive_for_enum_with_custom_value() {
+    let before: [u64; 3] = [0, 5, 6];
+    let after: Vec<Option<u64>> = before.iter()
+        .map(|&x| -> Option<Color> { num_renamed::FromPrimitive::from_u64(x) })
+        .map(|x| x.and_then(|x| num_renamed::ToPrimitive::to_u64(&x)))
+        .collect();
+    let before = before.into_iter().cloned().map(Some).collect::<Vec<_>>();
+
+    assert_eq!(before, after);
 }


### PR DESCRIPTION
Fixes #2.

An updated version of https://github.com/rust-num/num/pull/353 which includes suggestions outlined [here](https://github.com/rust-num/num/pull/353#pullrequestreview-83689635) and [here](https://github.com/rust-num/num/pull/353/files/76b5b2189f2b45e864e14c38c7856be578125931#r157100221):

- Update `quote` and `syn` to parse new Rust syntax;
- Update `compiletest_rs` to solve https://github.com/laumann/compiletest-rs/issues/86;
- Add support for arbitrary constant expressions as enum discriminants;
- Remove the need to `extern crate num` just for deriving.

Some notes:
- `#[derive(FromPrimitive)]` now uses if-else to do its job because non-literal expressions are not allowed for pattern matching.
- I added tests for self-containment of `#[derive]` alongside the code testing derivation functionality to keep the tests small. Would it be better to separate concerns?
- `with_custom_value` should have all three tests like `trivial`.