### PR TITLE
Use i64, and allow trivial_numeric_casts

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
             extern crate num as _num;
 
             impl _num::traits::ToPrimitive for #name {
+                #[allow(trivial_numeric_casts)]
                 fn to_i64(&self) -> Option<i64> {
                     #match_expr
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
             extern crate num as _num;
 
             impl _num::traits::FromPrimitive for #name {
+                #[allow(trivial_numeric_casts)]
                 fn from_i64(#from_i64_var: i64) -> Option<Self> {
                     #(#clauses else)* {
                         None

--- a/tests/issue-6.rs
+++ b/tests/issue-6.rs
@@ -3,14 +3,15 @@ extern crate num;
 #[macro_use]
 extern crate num_derive;
 
-#[derive(FromPrimitive)]
+#[derive(FromPrimitive, ToPrimitive)]
 pub enum SomeEnum {
     A = 1
 }
 
 #[test]
 fn test_trivial_numeric_casts() {
-    use num::FromPrimitive;
+    use num::{FromPrimitive, ToPrimitive};
     assert!(SomeEnum::from_u64(1).is_some());
     assert!(SomeEnum::from_i64(-1).is_none());
+    assert_eq!(SomeEnum::A.to_u64(), Some(1));
 }

--- a/tests/issue-6.rs
+++ b/tests/issue-6.rs
@@ -1,0 +1,16 @@
+#![deny(trivial_numeric_casts)]
+extern crate num;
+#[macro_use]
+extern crate num_derive;
+
+#[derive(FromPrimitive)]
+pub enum SomeEnum {
+    A = 1
+}
+
+#[test]
+fn test_trivial_numeric_casts() {
+    use num::FromPrimitive;
+    assert!(SomeEnum::from_u64(1).is_some());
+    assert!(SomeEnum::from_i64(-1).is_none());
+}


### PR DESCRIPTION
The traits are implemented from 64-bit values, and we don't want to lose
any bits when comparing on platforms with smaller `isize`.

Simple enum expressions may have no explicit type, like `A = 1`, so then
the derived `1 as i64` is inferred like `1i64 as i64`, a trivial numeric
cast.  But it's quite possible that other expressions could have explicit
types, so we can't just assign it directly either.  The simple solution is
to just allow the `trivial_numeric_casts` in derived code.

Fixes #6.