### PR TITLE
unused qualifications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = [ "science" ]
 license = "MIT/Apache-2.0"
 name = "num-derive"
 repository = "https://github.com/rust-num/num-derive"
-version = "0.1.43"
+version = "0.1.44"
 readme = "README.md"
 
 [dependencies]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,10 @@
+# Release 0.1.44
+
+- [The derived code now explicitly allows `unused_qualifications`][9], so users
+  that globally deny that lint don't encounter an error.
+
+[9]: https://github.com/rust-num/num-derive/pull/9
+
 # Release 0.1.43
 
 - [The derived code now explicitly allows `trivial_numeric_casts`][7], so users

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,6 +148,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
 
     let res = quote! {
         #[allow(non_upper_case_globals)]
+        #[allow(unused_qualifications)]
         const #dummy_const: () = {
             extern crate num as _num;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
 
     let res = quote! {
         #[allow(non_upper_case_globals)]
+        #[allow(unused_qualifications)]
         const #dummy_const: () = {
             extern crate num as _num;
 

--- a/tests/issue-9.rs
+++ b/tests/issue-9.rs
@@ -1,0 +1,15 @@
+#![deny(unused_qualifications)]
+extern crate num;
+#[macro_use]
+extern crate num_derive;
+use num::ToPrimitive;
+
+#[derive(ToPrimitive)]
+pub enum SomeEnum {
+    A = 1
+}
+
+#[test]
+fn test_trivial_numeric_casts() {
+    assert!(SomeEnum::A.to_i64().is_some());
+}

--- a/tests/issue-9.rs
+++ b/tests/issue-9.rs
@@ -2,14 +2,17 @@
 extern crate num;
 #[macro_use]
 extern crate num_derive;
+use num::FromPrimitive;
 use num::ToPrimitive;
 
-#[derive(ToPrimitive)]
+#[derive(FromPrimitive, ToPrimitive)]
 pub enum SomeEnum {
     A = 1
 }
 
 #[test]
-fn test_trivial_numeric_casts() {
+fn test_unused_qualifications() {
+    assert!(SomeEnum::from_u64(1).is_some());
+    assert!(SomeEnum::from_i64(-1).is_none());
     assert!(SomeEnum::A.to_i64().is_some());
 }


### PR DESCRIPTION
This code won't work on 0.1.43:
```rust
#![deny(trivial_numeric_casts)]
#![deny(unused_qualifications)]
extern crate num;
#[macro_use]
extern crate num_derive;
use num::ToPrimitive;

#[derive(ToPrimitive)]
pub enum SomeEnum {
    A = 1
}

fn main() {
    println!("{}", SomeEnum::A.to_i64().unwrap())
}
```
This is an attempt to fix it