### PR TITLE
Add std feature to Cargo manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,21 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-num-traits = "0.2"
 proc-macro2 = "0.4.2"
 quote = "0.6"
 syn = "0.15"
+
+[dependencies.num-traits]
+version = "0.2"
+default-features = false
 
 [dev-dependencies]
 num = "0.2"
 
 [features]
+default = ["std"]
 full-syntax = ["syn/full"]
+std = ["num-traits/std"]
 
 [lib]
 name = "num_derive"


### PR DESCRIPTION
This enables use of this crate in environments where std is not
available.