### PR TITLE
Allow deriving for no-std targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,19 @@ env:
   matrix:
     - # no features
     - FEATURES="full-syntax"
+
+matrix:
+  include:
+    # try a no-std target
+    - rust: stable
+      env: TARGET=thumbv6m-none-eabi
+      before_script:
+        - rustup target add "$TARGET"
+      script:
+        # This test crate is intentionally separate, because we need
+        # independent features for no-std. (rust-lang/cargo#2589)
+        - cd check && cargo check --target "$TARGET"
+
 sudo: false
 script:
   - cargo build --verbose --features="$FEATURES"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ readme = "README.md"
 build = "build.rs"
 
 [dependencies]
-num-traits = "0.2"
 proc-macro2 = "0.4.2"
 quote = "0.6"
 syn = "0.15"
 
 [dev-dependencies]
 num = "0.2"
+num-traits = "0.2"
 
 [features]
 full-syntax = ["syn/full"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = [ "science" ]
 license = "MIT/Apache-2.0"
 name = "num-derive"
 repository = "https://github.com/rust-num/num-derive"
-version = "0.2.3"
+version = "0.2.4"
 readme = "README.md"
 build = "build.rs"
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,9 @@
+# Release 0.2.4 (2019-01-25)
+
+- [Adjusted dependencies to allow no-std targets][22].
+
+[22]: https://github.com/rust-num/num-derive/pull/22
+
 # Release 0.2.3 (2018-10-03)
 
 - [Added newtype deriving][17] for `FromPrimitive`, `ToPrimitive`,

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "check"
+version = "0.1.0"
+authors = ["Josh Stone <cuviper@gmail.com>"]
+edition = "2018"
+
+[dependencies.num-derive]
+path = ".."
+
+[dependencies.num-traits]
+version = "0.2"
+default-features = false

--- a/check/src/lib.rs
+++ b/check/src/lib.rs
@@ -1,0 +1,8 @@
+#![no_std]
+
+#[derive(num_derive::FromPrimitive)]
+pub enum ABC {
+    A,
+    B,
+    C,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,7 +178,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
                 }
             }
         } else {
-            quote!{}
+            quote! {}
         };
 
         quote! {
@@ -251,7 +251,8 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
                         Some(#name::#ident)
                     }
                 }
-            }).collect();
+            })
+            .collect();
 
         let from_i64_var = if clauses.is_empty() {
             quote!(_)
@@ -345,7 +346,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                 }
             }
         } else {
-            quote!{}
+            quote! {}
         };
 
         quote! {
@@ -500,7 +501,8 @@ pub fn num_ops(input: TokenStream) -> TokenStream {
                 }
             }
         },
-    ).into()
+    )
+    .into()
 }
 
 /// Derives [`num_traits::NumCast`][num_cast] for newtypes.  The inner type must already implement
@@ -523,7 +525,8 @@ pub fn num_cast(input: TokenStream) -> TokenStream {
                 }
             }
         },
-    ).into()
+    )
+    .into()
 }
 
 /// Derives [`num_traits::Zero`][zero] for newtypes.  The inner type must already implement `Zero`.
@@ -548,7 +551,8 @@ pub fn zero(input: TokenStream) -> TokenStream {
                 }
             }
         },
-    ).into()
+    )
+    .into()
 }
 
 /// Derives [`num_traits::One`][one] for newtypes.  The inner type must already implement `One`.
@@ -573,7 +577,8 @@ pub fn one(input: TokenStream) -> TokenStream {
                 }
             }
         },
-    ).into()
+    )
+    .into()
 }
 
 /// Derives [`num_traits::Num`][num] for newtypes.  The inner type must already implement `Num`.
@@ -596,7 +601,8 @@ pub fn num(input: TokenStream) -> TokenStream {
                 }
             }
         },
-    ).into()
+    )
+    .into()
 }
 
 /// Derives [`num_traits::Float`][float] for newtypes.  The inner type must already implement
@@ -788,5 +794,6 @@ pub fn float(input: TokenStream) -> TokenStream {
                 }
             }
         },
-    ).into()
+    )
+    .into()
 }


### PR DESCRIPTION
By pulling in `num-traits` as a direct dependency, we corrupt the
feature selection for anybody using `num-derive` too, which makes it
impossible to use on no-std targets. We really only need it for testing
as a dev-dependency though.