### PR TITLE
README.md: fix num-derive version in Cargo.toml snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 num-traits = "0.2"
-num-derive = "0.3"
+num-derive = "0.2"
 ```
 
 and this to your crate root:


### PR DESCRIPTION
There's no 0.3 yet: https://crates.io/crates/num-derive/versions