### PR TITLE
Disable functions for i128 if not supported.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ name = "num_derive"
 proc-macro = true
 test = false
 
+[build-dependencies]
+autocfg = "1"
+
 # Most of the tests are left implicily detected, compiled for Rust 2018,
 # but let's try a few of them with the old 2015 edition too.
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,14 @@
+use autocfg;
+use std::env;
+
+fn main() {
+    let ac = autocfg::new();
+
+    // If the "i128" feature is explicity requested, don't bother probing for it.
+    // It will still cause a build error if that was set improperly.
+    if env::var_os("CARGO_FEATURE_I128").is_some() || ac.probe_type("i128") {
+        autocfg::emit("has_i128");
+    }
+
+    autocfg::rerun_path("build.rs");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
                     <#inner_ty as #import::FromPrimitive>::from_i32(n).map(#name)
                 }
                 #[inline]
+                #[cfg(has_i128)]
                 fn from_i128(n: i128) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_i128(n).map(#name)
                 }
@@ -303,6 +304,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
                     <#inner_ty as #import::FromPrimitive>::from_u32(n).map(#name)
                 }
                 #[inline]
+                #[cfg(has_i128)]
                 fn from_u128(n: u128) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_u128(n).map(#name)
                 }
@@ -457,6 +459,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                     <#inner_ty as #import::ToPrimitive>::to_i32(&self.0)
                 }
                 #[inline]
+                #[cfg(has_i128)]
                 fn to_i128(&self) -> Option<i128> {
                     <#inner_ty as #import::ToPrimitive>::to_i128(&self.0)
                 }
@@ -477,6 +480,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                     <#inner_ty as #import::ToPrimitive>::to_u32(&self.0)
                 }
                 #[inline]
+                #[cfg(has_i128)]
                 fn to_u128(&self) -> Option<u128> {
                     <#inner_ty as #import::ToPrimitive>::to_u128(&self.0)
                 }


### PR DESCRIPTION
For targets that don't support `i128` and `u128`, disable functions that require them in the `FromPrimitive` and `ToPrimitive` traits. This is consistent with the num-traits crate which does not require these for targets that don't support them. Fixes #46.