### PR TITLE
Make Float work with no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -765,7 +765,7 @@ pub fn float(input: TokenStream) -> TokenStream {
                 <#inner_ty as #import::Float>::is_normal(self.0)
             }
             #[inline]
-            fn classify(self) -> ::std::num::FpCategory {
+            fn classify(self) -> ::core::num::FpCategory {
                 <#inner_ty as #import::Float>::classify(self.0)
             }
             #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,59 +258,59 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
     let impl_ = if let Some(inner_ty) = newtype_inner(&ast.data) {
         quote! {
             impl #import::FromPrimitive for #name {
-                #[inline]
+                #[inline(always)]
                 fn from_i64(n: i64) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_i64(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_u64(n: u64) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_u64(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_isize(n: isize) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_isize(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_i8(n: i8) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_i8(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_i16(n: i16) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_i16(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_i32(n: i32) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_i32(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_i128(n: i128) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_i128(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_usize(n: usize) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_usize(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_u8(n: u8) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_u8(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_u16(n: u16) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_u16(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_u32(n: u32) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_u32(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_u128(n: u128) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_u128(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_f32(n: f32) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_f32(n).map(#name)
                 }
-                #[inline]
+                #[inline(always)]
                 fn from_f64(n: f64) -> Option<Self> {
                     <#inner_ty as #import::FromPrimitive>::from_f64(n).map(#name)
                 }
@@ -363,7 +363,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
                     }
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn from_u64(n: u64) -> Option<Self> {
                     Self::from_i64(n as i64)
                 }
@@ -432,59 +432,59 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
     let impl_ = if let Some(inner_ty) = newtype_inner(&ast.data) {
         quote! {
             impl #import::ToPrimitive for #name {
-                #[inline]
+                #[inline(always)]
                 fn to_i64(&self) -> Option<i64> {
                     <#inner_ty as #import::ToPrimitive>::to_i64(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_u64(&self) -> Option<u64> {
                     <#inner_ty as #import::ToPrimitive>::to_u64(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_isize(&self) -> Option<isize> {
                     <#inner_ty as #import::ToPrimitive>::to_isize(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_i8(&self) -> Option<i8> {
                     <#inner_ty as #import::ToPrimitive>::to_i8(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_i16(&self) -> Option<i16> {
                     <#inner_ty as #import::ToPrimitive>::to_i16(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_i32(&self) -> Option<i32> {
                     <#inner_ty as #import::ToPrimitive>::to_i32(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_i128(&self) -> Option<i128> {
                     <#inner_ty as #import::ToPrimitive>::to_i128(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_usize(&self) -> Option<usize> {
                     <#inner_ty as #import::ToPrimitive>::to_usize(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_u8(&self) -> Option<u8> {
                     <#inner_ty as #import::ToPrimitive>::to_u8(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_u16(&self) -> Option<u16> {
                     <#inner_ty as #import::ToPrimitive>::to_u16(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_u32(&self) -> Option<u32> {
                     <#inner_ty as #import::ToPrimitive>::to_u32(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_u128(&self) -> Option<u128> {
                     <#inner_ty as #import::ToPrimitive>::to_u128(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_f32(&self) -> Option<f32> {
                     <#inner_ty as #import::ToPrimitive>::to_f32(&self.0)
                 }
-                #[inline]
+                #[inline(always)]
                 fn to_f64(&self) -> Option<f64> {
                     <#inner_ty as #import::ToPrimitive>::to_f64(&self.0)
                 }
@@ -538,7 +538,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                     #match_expr
                 }
 
-                #[inline]
+                #[inline(always)]
                 fn to_u64(&self) -> Option<u64> {
                     self.to_i64().map(|x| x as u64)
                 }
@@ -567,35 +567,35 @@ pub fn num_ops(input: TokenStream) -> TokenStream {
     let impl_ = quote! {
         impl ::core::ops::Add for #name {
             type Output = Self;
-            #[inline]
+            #[inline(always)]
             fn add(self, other: Self) -> Self {
                 #name(<#inner_ty as ::core::ops::Add>::add(self.0, other.0))
             }
         }
         impl ::core::ops::Sub for #name {
             type Output = Self;
-            #[inline]
+            #[inline(always)]
             fn sub(self, other: Self) -> Self {
                 #name(<#inner_ty as ::core::ops::Sub>::sub(self.0, other.0))
             }
         }
         impl ::core::ops::Mul for #name {
             type Output = Self;
-            #[inline]
+            #[inline(always)]
             fn mul(self, other: Self) -> Self {
                 #name(<#inner_ty as ::core::ops::Mul>::mul(self.0, other.0))
             }
         }
         impl ::core::ops::Div for #name {
             type Output = Self;
-            #[inline]
+            #[inline(always)]
             fn div(self, other: Self) -> Self {
                 #name(<#inner_ty as ::core::ops::Div>::div(self.0, other.0))
             }
         }
         impl ::core::ops::Rem for #name {
             type Output = Self;
-            #[inline]
+            #[inline(always)]
             fn rem(self, other: Self) -> Self {
                 #name(<#inner_ty as ::core::ops::Rem>::rem(self.0, other.0))
             }
@@ -618,7 +618,7 @@ pub fn num_cast(input: TokenStream) -> TokenStream {
 
     let impl_ = quote! {
         impl #import::NumCast for #name {
-            #[inline]
+            #[inline(always)]
             fn from<T: #import::ToPrimitive>(n: T) -> Option<Self> {
                 <#inner_ty as #import::NumCast>::from(n).map(#name)
             }
@@ -641,11 +641,11 @@ pub fn zero(input: TokenStream) -> TokenStream {
 
     let impl_ = quote! {
         impl #import::Zero for #name {
-            #[inline]
+            #[inline(always)]
             fn zero() -> Self {
                 #name(<#inner_ty as #import::Zero>::zero())
             }
-            #[inline]
+            #[inline(always)]
             fn is_zero(&self) -> bool {
                 <#inner_ty as #import::Zero>::is_zero(&self.0)
             }
@@ -668,11 +668,11 @@ pub fn one(input: TokenStream) -> TokenStream {
 
     let impl_ = quote! {
         impl #import::One for #name {
-            #[inline]
+            #[inline(always)]
             fn one() -> Self {
                 #name(<#inner_ty as #import::One>::one())
             }
-            #[inline]
+            #[inline(always)]
             fn is_one(&self) -> bool {
                 <#inner_ty as #import::One>::is_one(&self.0)
             }
@@ -696,7 +696,7 @@ pub fn num(input: TokenStream) -> TokenStream {
     let impl_ = quote! {
         impl #import::Num for #name {
             type FromStrRadixErr = <#inner_ty as #import::Num>::FromStrRadixErr;
-            #[inline]
+            #[inline(always)]
             fn from_str_radix(s: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
                 <#inner_ty as #import::Num>::from_str_radix(s, radix).map(#name)
             }
@@ -720,232 +720,232 @@ pub fn float(input: TokenStream) -> TokenStream {
 
     let impl_ = quote! {
         impl #import::Float for #name {
-            #[inline]
+            #[inline(always)]
             fn nan() -> Self {
                 #name(<#inner_ty as #import::Float>::nan())
             }
-            #[inline]
+            #[inline(always)]
             fn infinity() -> Self {
                 #name(<#inner_ty as #import::Float>::infinity())
             }
-            #[inline]
+            #[inline(always)]
             fn neg_infinity() -> Self {
                 #name(<#inner_ty as #import::Float>::neg_infinity())
             }
-            #[inline]
+            #[inline(always)]
             fn neg_zero() -> Self {
                 #name(<#inner_ty as #import::Float>::neg_zero())
             }
-            #[inline]
+            #[inline(always)]
             fn min_value() -> Self {
                 #name(<#inner_ty as #import::Float>::min_value())
             }
-            #[inline]
+            #[inline(always)]
             fn min_positive_value() -> Self {
                 #name(<#inner_ty as #import::Float>::min_positive_value())
             }
-            #[inline]
+            #[inline(always)]
             fn max_value() -> Self {
                 #name(<#inner_ty as #import::Float>::max_value())
             }
-            #[inline]
+            #[inline(always)]
             fn is_nan(self) -> bool {
                 <#inner_ty as #import::Float>::is_nan(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn is_infinite(self) -> bool {
                 <#inner_ty as #import::Float>::is_infinite(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn is_finite(self) -> bool {
                 <#inner_ty as #import::Float>::is_finite(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn is_normal(self) -> bool {
                 <#inner_ty as #import::Float>::is_normal(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn classify(self) -> ::core::num::FpCategory {
                 <#inner_ty as #import::Float>::classify(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn floor(self) -> Self {
                 #name(<#inner_ty as #import::Float>::floor(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn ceil(self) -> Self {
                 #name(<#inner_ty as #import::Float>::ceil(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn round(self) -> Self {
                 #name(<#inner_ty as #import::Float>::round(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn trunc(self) -> Self {
                 #name(<#inner_ty as #import::Float>::trunc(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn fract(self) -> Self {
                 #name(<#inner_ty as #import::Float>::fract(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn abs(self) -> Self {
                 #name(<#inner_ty as #import::Float>::abs(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn signum(self) -> Self {
                 #name(<#inner_ty as #import::Float>::signum(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn is_sign_positive(self) -> bool {
                 <#inner_ty as #import::Float>::is_sign_positive(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn is_sign_negative(self) -> bool {
                 <#inner_ty as #import::Float>::is_sign_negative(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn mul_add(self, a: Self, b: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::mul_add(self.0, a.0, b.0))
             }
-            #[inline]
+            #[inline(always)]
             fn recip(self) -> Self {
                 #name(<#inner_ty as #import::Float>::recip(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn powi(self, n: i32) -> Self {
                 #name(<#inner_ty as #import::Float>::powi(self.0, n))
             }
-            #[inline]
+            #[inline(always)]
             fn powf(self, n: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::powf(self.0, n.0))
             }
-            #[inline]
+            #[inline(always)]
             fn sqrt(self) -> Self {
                 #name(<#inner_ty as #import::Float>::sqrt(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn exp(self) -> Self {
                 #name(<#inner_ty as #import::Float>::exp(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn exp2(self) -> Self {
                 #name(<#inner_ty as #import::Float>::exp2(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn ln(self) -> Self {
                 #name(<#inner_ty as #import::Float>::ln(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn log(self, base: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::log(self.0, base.0))
             }
-            #[inline]
+            #[inline(always)]
             fn log2(self) -> Self {
                 #name(<#inner_ty as #import::Float>::log2(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn log10(self) -> Self {
                 #name(<#inner_ty as #import::Float>::log10(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn max(self, other: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::max(self.0, other.0))
             }
-            #[inline]
+            #[inline(always)]
             fn min(self, other: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::min(self.0, other.0))
             }
-            #[inline]
+            #[inline(always)]
             fn abs_sub(self, other: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::abs_sub(self.0, other.0))
             }
-            #[inline]
+            #[inline(always)]
             fn cbrt(self) -> Self {
                 #name(<#inner_ty as #import::Float>::cbrt(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn hypot(self, other: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::hypot(self.0, other.0))
             }
-            #[inline]
+            #[inline(always)]
             fn sin(self) -> Self {
                 #name(<#inner_ty as #import::Float>::sin(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn cos(self) -> Self {
                 #name(<#inner_ty as #import::Float>::cos(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn tan(self) -> Self {
                 #name(<#inner_ty as #import::Float>::tan(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn asin(self) -> Self {
                 #name(<#inner_ty as #import::Float>::asin(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn acos(self) -> Self {
                 #name(<#inner_ty as #import::Float>::acos(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn atan(self) -> Self {
                 #name(<#inner_ty as #import::Float>::atan(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn atan2(self, other: Self) -> Self {
                 #name(<#inner_ty as #import::Float>::atan2(self.0, other.0))
             }
-            #[inline]
+            #[inline(always)]
             fn sin_cos(self) -> (Self, Self) {
                 let (x, y) = <#inner_ty as #import::Float>::sin_cos(self.0);
                 (#name(x), #name(y))
             }
-            #[inline]
+            #[inline(always)]
             fn exp_m1(self) -> Self {
                 #name(<#inner_ty as #import::Float>::exp_m1(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn ln_1p(self) -> Self {
                 #name(<#inner_ty as #import::Float>::ln_1p(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn sinh(self) -> Self {
                 #name(<#inner_ty as #import::Float>::sinh(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn cosh(self) -> Self {
                 #name(<#inner_ty as #import::Float>::cosh(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn tanh(self) -> Self {
                 #name(<#inner_ty as #import::Float>::tanh(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn asinh(self) -> Self {
                 #name(<#inner_ty as #import::Float>::asinh(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn acosh(self) -> Self {
                 #name(<#inner_ty as #import::Float>::acosh(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn atanh(self) -> Self {
                 #name(<#inner_ty as #import::Float>::atanh(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn integer_decode(self) -> (u64, i16, i8) {
                 <#inner_ty as #import::Float>::integer_decode(self.0)
             }
-            #[inline]
+            #[inline(always)]
             fn epsilon() -> Self {
                 #name(<#inner_ty as #import::Float>::epsilon())
             }
-            #[inline]
+            #[inline(always)]
             fn to_degrees(self) -> Self {
                 #name(<#inner_ty as #import::Float>::to_degrees(self.0))
             }
-            #[inline]
+            #[inline(always)]
             fn to_radians(self) -> Self {
                 #name(<#inner_ty as #import::Float>::to_radians(self.0))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -195,7 +195,7 @@ impl NumTraits {
         if self.explicit {
             output
         } else {
-            dummy_const_trick(trait_, &name, output)
+            dummy_const_trick(trait_, name, output)
         }
     }
 }
@@ -371,7 +371,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("FromPrimitive", &name, impl_).into()
+    import.wrap("FromPrimitive", name, impl_).into()
 }
 
 /// Derives [`num_traits::ToPrimitive`][to] for simple enums and newtypes.
@@ -546,7 +546,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("ToPrimitive", &name, impl_).into()
+    import.wrap("ToPrimitive", name, impl_).into()
 }
 
 const NEWTYPE_ONLY: &str = "This trait can only be derived for newtypes";
@@ -625,7 +625,7 @@ pub fn num_cast(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("NumCast", &name, impl_).into()
+    import.wrap("NumCast", name, impl_).into()
 }
 
 /// Derives [`num_traits::Zero`][zero] for newtypes.  The inner type must already implement `Zero`.
@@ -652,7 +652,7 @@ pub fn zero(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("Zero", &name, impl_).into()
+    import.wrap("Zero", name, impl_).into()
 }
 
 /// Derives [`num_traits::One`][one] for newtypes.  The inner type must already implement `One`.
@@ -679,7 +679,7 @@ pub fn one(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("One", &name, impl_).into()
+    import.wrap("One", name, impl_).into()
 }
 
 /// Derives [`num_traits::Num`][num] for newtypes.  The inner type must already implement `Num`.
@@ -703,7 +703,7 @@ pub fn num(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("Num", &name, impl_).into()
+    import.wrap("Num", name, impl_).into()
 }
 
 /// Derives [`num_traits::Float`][float] for newtypes.  The inner type must already implement
@@ -952,7 +952,7 @@ pub fn float(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("Float", &name, impl_).into()
+    import.wrap("Float", name, impl_).into()
 }
 
 mod test;


### PR DESCRIPTION
The Float macro is referencing ::std::num::FpCategory and thus doesn't work with no_std yet. Replacing it with ::core::num::FpCategory shouldn't break any existing code but provides no_std compatibility when needed.

After doing this change, I added two more commits to my fork. I think these should be pretty noncontroversial. Otherwise I'd already be happy if only the first one (e1a99e1) got merged.