### PR TITLE
Make Float work with no_std (rebased #50)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -763,7 +763,7 @@ pub fn float(input: TokenStream) -> TokenStream {
                 <#inner_ty as #import::Float>::is_normal(self.0)
             }
             #[inline]
-            fn classify(self) -> ::std::num::FpCategory {
+            fn classify(self) -> ::core::num::FpCategory {
                 <#inner_ty as #import::Float>::classify(self.0)
             }
             #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,7 +193,7 @@ impl NumTraits {
         if self.explicit {
             output
         } else {
-            dummy_const_trick(trait_, &name, output)
+            dummy_const_trick(trait_, name, output)
         }
     }
 }
@@ -369,7 +369,7 @@ pub fn from_primitive(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("FromPrimitive", &name, impl_).into()
+    import.wrap("FromPrimitive", name, impl_).into()
 }
 
 /// Derives [`num_traits::ToPrimitive`][to] for simple enums and newtypes.
@@ -544,7 +544,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("ToPrimitive", &name, impl_).into()
+    import.wrap("ToPrimitive", name, impl_).into()
 }
 
 const NEWTYPE_ONLY: &str = "This trait can only be derived for newtypes";
@@ -623,7 +623,7 @@ pub fn num_cast(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("NumCast", &name, impl_).into()
+    import.wrap("NumCast", name, impl_).into()
 }
 
 /// Derives [`num_traits::Zero`][zero] for newtypes.  The inner type must already implement `Zero`.
@@ -650,7 +650,7 @@ pub fn zero(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("Zero", &name, impl_).into()
+    import.wrap("Zero", name, impl_).into()
 }
 
 /// Derives [`num_traits::One`][one] for newtypes.  The inner type must already implement `One`.
@@ -677,7 +677,7 @@ pub fn one(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("One", &name, impl_).into()
+    import.wrap("One", name, impl_).into()
 }
 
 /// Derives [`num_traits::Num`][num] for newtypes.  The inner type must already implement `Num`.
@@ -701,7 +701,7 @@ pub fn num(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("Num", &name, impl_).into()
+    import.wrap("Num", name, impl_).into()
 }
 
 /// Derives [`num_traits::Float`][float] for newtypes.  The inner type must already implement
@@ -950,5 +950,5 @@ pub fn float(input: TokenStream) -> TokenStream {
         }
     };
 
-    import.wrap("Float", &name, impl_).into()
+    import.wrap("Float", name, impl_).into()
 }


### PR DESCRIPTION
- Use ::core::num::FpCategory when deriving Float to work with no_std
- Get rid of unnecessary double-borrowing to fix clippy lint
