### PR TITLE
Add special case to ToPrimitive for enums with primitive representation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,7 +492,8 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                 _ = repr_attr.parse_nested_meta(|meta| {
                     if let Some(ident) = meta.path.get_ident() {
                         if [
-                            "u8", "u16", "u32", "u64", "u128", "i8", "i16", "i32", "i64", "i128",
+                            "u8", "u16", "u32", "u64", "u128", "usize", "i8", "i16", "i32", "i64",
+                            "i128", "isize",
                         ]
                         .iter()
                         .any(|i| ident == i)
@@ -515,7 +516,7 @@ pub fn to_primitive(input: TokenStream) -> TokenStream {
                 impl #import::ToPrimitive for #name {
                     #[inline]
                     fn to_i64(&self) -> ::core::option::Option<i64> {
-                        Some(unsafe { *(self as *const Self as *const #discriminant_type) }.into())
+                        unsafe { *(self as *const Self as *const #discriminant_type) }.try_into().ok()
                     }
 
                     #[inline]


### PR DESCRIPTION
ToPrimitive can be safely derived for any enum with the #[repr(u*/i*)] attribute

See:
https://doc.rust-lang.org/reference/items/enumerations.html#pointer-casting
https://doc.rust-lang.org/std/mem/fn.discriminant.html#accessing-the-numeric-value-of-the-discriminant